### PR TITLE
Fixed issue where the same byte was read twice instead of chopping a...

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - 1.60.0
+          - 1.64.0
           - stable
           - beta
           - nightly 

--- a/src/coverage/coverage_mapping.rs
+++ b/src/coverage/coverage_mapping.rs
@@ -297,8 +297,8 @@ fn parse_coverage_functions(
     endian: Endianness,
     section: &Section<'_, '_>,
 ) -> Result<Vec<FunctionRecordV3>, SectionReadError> {
-    if let Ok(data) = section.data() {
-        let mut bytes = data;
+    if let Ok(original_data) = section.data() {
+        let mut bytes = original_data;
         let mut res = vec![];
         let section_len = bytes.len();
         while !bytes.is_empty() {
@@ -323,6 +323,7 @@ fn parse_coverage_functions(
                 filename_indices.push(id);
                 bytes = data;
             }
+
             let (data, expr_len) = parse_leb128::<NomError<_>>(bytes).unwrap();
             let expr_len = expr_len as usize;
             bytes = data;
@@ -406,8 +407,8 @@ fn parse_mapping_regions<'a>(
                         Ok(RegionKind::Code) | Ok(RegionKind::Skipped) => {}
                         Ok(RegionKind::Branch) => {
                             kind = RegionKind::Branch;
-                            let (_data, c1) = parse_leb128(bytes)?;
-                            let (data, c2) = parse_leb128(bytes)?;
+                            let (data, c1) = parse_leb128(bytes)?;
+                            let (data, c2) = parse_leb128(data)?;
 
                             counter = parse_counter(c1, expressions);
                             false_count = parse_counter(c2, expressions);


### PR DESCRIPTION
... new byte from bytes buffer in parse_mapping_regions.

The crash is gone, the output seem relevant to me, but a double check on this may be more than welcome !

However I'm a bit curious about how the entire llvm-profparser could even remotely work even though counter parsing was apparently quite dysfunctional and was causing parsing offsets, a bit of enlightenment for my own culture here would be welcome ! :)