### PR TITLE
Cache the name md5 hash inside NamedInstrProfRecord

### DIFF
--- a/src/coverage/coverage_mapping.rs
+++ b/src/coverage/coverage_mapping.rs
@@ -128,8 +128,7 @@ impl<'a> CoverageMapping<'a> {
         let mut result = HashMap::new();
         result.insert(Counter::default(), 0);
         let record = self.profile.records.iter().find(|x| {
-            x.hash == Some(func.header.fn_hash)
-                && Some(func.header.name_hash) == x.name.as_ref().map(compute_hash)
+            x.hash == Some(func.header.fn_hash) && Some(func.header.name_hash) == x.name_hash
         });
         if let Some(func_record) = record.as_ref() {
             for (id, count) in func_record.record.counts.iter().enumerate() {

--- a/src/coverage/mod.rs
+++ b/src/coverage/mod.rs
@@ -1,5 +1,3 @@
-use crate::instrumentation_profile::types::compute_hash;
-
 use nom::IResult;
 use std::collections::HashMap;
 use std::convert::TryFrom;

--- a/src/instrumentation_profile/indexed_profile.rs
+++ b/src/instrumentation_profile/indexed_profile.rs
@@ -187,8 +187,11 @@ impl InstrProfReader for IndexedInstrProf {
             profile
                 .symtab
                 .add_func_name(name.clone(), Some(Endianness::Little));
+
+            let name_hash = compute_hash(&name);
             let record = NamedInstrProfRecord {
                 name: Some(name),
+                name_hash: Some(name_hash),
                 hash: Some(*hash),
                 record: v.clone(),
             };

--- a/src/instrumentation_profile/raw_profile.rs
+++ b/src/instrumentation_profile/raw_profile.rs
@@ -358,15 +358,19 @@ where
                     Self::read_value_profiling_data(&header, data, input, &mut record)?;
                 input = bytes;
                 let name = symtab.names.get(&data.name_ref).cloned();
-                let hash = if name.is_some() {
-                    Some(data.func_hash)
+                let (hash, name_hash) = if let Some(ref name) = name {
+                    (Some(data.func_hash), Some(compute_hash(name)))
                 } else {
-                    None
+                    (None, None)
                 };
                 debug!("Parsed record: {:?} {:?} {:?}", name, hash, record);
-                result
-                    .records
-                    .push(NamedInstrProfRecord { name, hash, record });
+
+                result.records.push(NamedInstrProfRecord {
+                    name,
+                    name_hash,
+                    hash,
+                    record,
+                });
             }
             result.symtab = symtab;
             Ok((input, result))

--- a/src/instrumentation_profile/text_profile.rs
+++ b/src/instrumentation_profile/text_profile.rs
@@ -237,6 +237,7 @@ impl InstrProfReader for TextInstrProf {
             let name = std::str::from_utf8(name).map(|x| x.to_string()).ok();
             result.records.push(NamedInstrProfRecord {
                 name: name.clone(),
+                name_hash: name.as_ref().map(compute_hash),
                 hash: Some(hash),
                 record,
             });

--- a/src/instrumentation_profile/types.rs
+++ b/src/instrumentation_profile/types.rs
@@ -210,6 +210,7 @@ impl InstrumentationProfile {
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct NamedInstrProfRecord {
     pub name: Option<String>,
+    pub name_hash: Option<u64>,
     pub hash: Option<u64>,
     pub record: InstrProfRecord,
 }


### PR DESCRIPTION
Not recomputing it everytime brings `CoverageMapping::generate_report` from 30s per test to 1s per test on my system when used inside cargo tarpaulin.

---

I realised the `Mapping coverage data to source` part of cargo tarpaulin was very slow for me, and `CoverageMapping::generate_report` was taking most of it. The flamegraph showed that most of that time was spend recomputing md5 hash in `get_simple_counters`. Computing the hash only once when creating the `NamedInstrProfRecord` dramatically cuts the run time.

There might be more gains to have by changing the data structure from a `Vec<NamedInstrProfRecord>` to a `HashMap<(u64, u64), NamedInstrProfRecord>` (using the fn_hash and name_hash as keys), but I'm not sure of the greater implications of this.