### PR TITLE
fix: use HashMap to cache NamedInstrProfRecord

### DIFF
--- a/src/bin/profparser.rs
+++ b/src/bin/profparser.rs
@@ -212,7 +212,7 @@ impl ShowCommand {
         let mut shown_funcs = 0;
         let mut below_cutoff_funcs = 0;
         let topn = self.topn.unwrap_or_default();
-        for func in &profile.records {
+        for func in profile.records.records() {
             if func.name.is_none() || func.hash.is_none() {
                 continue;
             }

--- a/src/coverage/coverage_mapping.rs
+++ b/src/coverage/coverage_mapping.rs
@@ -127,11 +127,12 @@ impl<'a> CoverageMapping<'a> {
     pub(crate) fn get_simple_counters(&self, func: &FunctionRecordV3) -> HashMap<Counter, i64> {
         let mut result = HashMap::new();
         result.insert(Counter::default(), 0);
-        let record = self.profile.records.iter().find(|x| {
-            x.hash == Some(func.header.fn_hash) && Some(func.header.name_hash) == x.name_hash
-        });
-        if let Some(func_record) = record.as_ref() {
-            for (id, count) in func_record.record.counts.iter().enumerate() {
+        let record = self
+            .profile
+            .records
+            .get_by_hashes(&(func.header.name_hash, func.header.fn_hash));
+        if let Some(record) = record {
+            for (id, count) in record.record.counts.iter().enumerate() {
                 result.insert(Counter::instrumentation(id as u64), *count as i64);
             }
         }

--- a/src/instrumentation_profile/text_profile.rs
+++ b/src/instrumentation_profile/text_profile.rs
@@ -377,7 +377,7 @@ mod tests {
         assert_eq!(report.symtab.len(), 1);
         assert_eq!(report.symtab.names.get(&0).unwrap(), "main");
 
-        let rec = &report.records[0];
+        let rec = &report.records.records()[0];
 
         assert_eq!(rec.name, Some("main".to_string()));
         assert_eq!(rec.hash, Some(0));

--- a/tests/cov.rs
+++ b/tests/cov.rs
@@ -229,7 +229,7 @@ fn check_mapping_consistency() {
 
     let mapping = CoverageMapping::new(&[obj], &instr).unwrap();
     let info = &mapping.mapping_info[0];
-    for record in &instr.records {
+    for record in instr.records.records() {
         let fun = info
             .cov_fun
             .iter()

--- a/tests/profdata.rs
+++ b/tests/profdata.rs
@@ -1,6 +1,5 @@
 use llvm_profparser::{merge_profiles, parse, parse_bytes};
 use pretty_assertions::assert_eq;
-use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::fs::read_dir;
 use std::path::PathBuf;
@@ -65,8 +64,8 @@ fn check_merge_command(files: &[PathBuf], id: &str) {
             llvm_merged.has_csir_level_profile(),
             rust_merged.has_csir_level_profile()
         );
-        let llvm_records = llvm_merged.records.iter().collect::<HashSet<_>>();
-        let rust_records = rust_merged.records.iter().collect::<HashSet<_>>();
+        let rust_records = rust_merged.records.records().iter().collect::<Vec<_>>();
+        let llvm_records = llvm_merged.records.records().iter().collect::<Vec<_>>();
         assert!(!llvm_records.is_empty());
         std::assert_eq!(llvm_records, rust_records);
     } else {
@@ -165,8 +164,8 @@ fn check_against_text(ext: &OsStr) {
                 text_prof.has_csir_level_profile(),
                 parsed_prof.has_csir_level_profile()
             );
-            let text_records = text_prof.records.iter().collect::<HashSet<_>>();
-            let parse_records = parsed_prof.records.iter().collect::<HashSet<_>>();
+            let text_records = text_prof.records.iter().collect::<Vec<_>>();
+            let parse_records = parsed_prof.records.iter().collect::<Vec<_>>();
             assert_eq!(text_records, parse_records);
         } else {
             println!("{} failed", raw_file.path().display());


### PR DESCRIPTION
changes within this PR

- replaced the record `Vec<>` with a struct the allows indexing by hash & name directly to avoid linear search with `find`

comparison of results when running tarpaulin against tarpaulin repo 
```
before:
67.92s user 7.00s system 46% cpu 2:41.16 total

after:
32.73s user 7.26s system 36% cpu 1:49.07 total
```