### PR TITLE
check profdata output via parsing yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - 1.64.0
+          - 1.65.0
           - stable
           - beta
           - nightly 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ cfg-if = "1.0.0"
 criterion = { version = "0.3.5", features = ["html_reports"] }
 pretty_assertions = "0.7"
 regex = "1.5.6"
+serde = { version = "1.0.165", features = ["derive"] }
+serde_yaml = "0.9.22"
 
 [[bin]]
 name = "profparser"


### PR DESCRIPTION
Unlocks new optimisations by meaning we can move away from a vec of results matching the llvm implementation