### PR TITLE
Do some speedup stuff again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - 1.80.0
+          - 1.82.0
           - stable
           - beta
           - nightly 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2]
+### Changed
+- More performance improvements this time changing search order to prefer deeper expression nodes first
+
 ## [0.8.1] 2025-05-06
 ### Changed
 - Increased usage of memoization of hashes -> profiles to speedup report generation more

--- a/src/coverage/coverage_mapping.rs
+++ b/src/coverage/coverage_mapping.rs
@@ -175,7 +175,7 @@ impl<'a> CoverageMapping<'a> {
 
                 let mut pending_exprs = vec![];
 
-                for (expr_index, expr) in func.expressions.iter().enumerate() {
+                for (expr_index, expr) in func.expressions.iter().enumerate().rev() {
                     let lhs = region_ids.get(&expr.lhs);
                     let rhs = region_ids.get(&expr.rhs);
                     match (lhs, rhs) {

--- a/src/coverage/coverage_mapping.rs
+++ b/src/coverage/coverage_mapping.rs
@@ -140,6 +140,7 @@ impl<'a> CoverageMapping<'a> {
         result.insert(Counter::default(), 0);
         let record = self.profile.find_record_by_hash(func.header.name_hash);
         if let Some(func_record) = record.as_ref() {
+            result.reserve(func_record.record.counts.len());
             for (id, count) in func_record.record.counts.iter().enumerate() {
                 result.insert(Counter::instrumentation(id as u64), *count as i64);
             }

--- a/src/instrumentation_profile/raw_profile.rs
+++ b/src/instrumentation_profile/raw_profile.rs
@@ -390,7 +390,7 @@ where
                     Self::read_value_profiling_data(&header, data, input, &mut record)?;
                 input = bytes;
                 let name = symtab.names.get(&data.name_ref).cloned();
-                let (hash, name_hash) = if symtab.contains(data.name_ref) {
+                let (hash, name_hash) = if name.is_some() {
                     // Previously this function calculated the function hash itself to be
                     // ultra-defensive against the profraw format changing hash calculation method
                     // so we try not to rely on reimplementing it. However, md5::compute was more

--- a/src/instrumentation_profile/types.rs
+++ b/src/instrumentation_profile/types.rs
@@ -67,6 +67,10 @@ impl Symtab {
         self.names.insert(hash, name);
     }
 
+    pub fn add_func_name_with_hash(&mut self, name: String, hash: u64) {
+        self.names.insert(hash, name);
+    }
+
     pub fn contains(&self, hash: u64) -> bool {
         self.names.contains_key(&hash)
     }


### PR DESCRIPTION
Two performance regressions I should probably figure out (maybe just system noise though)

```
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.8s, or reduce sample count to 60.
coverage mapping        time:   [77.426 ms 79.072 ms 81.046 ms]                             
                        change: [+6.2990% +8.8096% +11.628%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) high mild
  10 (10.00%) high severe

Benchmarking report generation: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 81.9s, or reduce sample count to 10.
report generation       time:   [806.43 ms 809.27 ms 812.17 ms]                              
                        change: [-79.923% -79.433% -78.921%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking subreport generation: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 12.1s, or reduce sample count to 40.
subreport generation    time:   [117.87 ms 119.28 ms 120.84 ms]                                 
                        change: [-22.306% -21.266% -20.132%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  9 (9.00%) high mild
  4 (4.00%) high severe

     Running benches/profdata_parsing.rs (target/release/deps/profdata_parsing-734518ffb23e545c)
Gnuplot not found, using plotters backend
profdata_parse_cargo    time:   [18.734 ms 19.136 ms 19.613 ms]                                 
                        change: [-22.091% -20.090% -17.694%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  3 (3.00%) high mild
  9 (9.00%) high severe

     Running benches/profraw_parsing.rs (target/release/deps/profraw_parsing-e56fea141cf59082)
Gnuplot not found, using plotters backend
Benchmarking profraw_parse_tokio: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.3s, or reduce sample count to 90.
profraw_parse_tokio     time:   [52.722 ms 53.620 ms 54.631 ms]                                
                        change: [-19.963% -18.530% -16.749%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  3 (3.00%) low mild
  8 (8.00%) high mild
  6 (6.00%) high severe

Benchmarking profraw_parse_cargo: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.0s, or reduce sample count to 60.
profraw_parse_cargo     time:   [77.907 ms 78.564 ms 79.221 ms]                                
                        change: [-17.393% -16.352% -15.324%] (p = 0.00 < 0.05)
                        Performance has improved.

     Running benches/report_merging.rs (target/release/deps/report_merging-adf23cc85e45e627)
Gnuplot not found, using plotters backend
Benchmarking merge: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 23.1s, or reduce sample count to 20.
merge                   time:   [272.11 ms 279.45 ms 286.81 ms]                  
                        change: [-1.3100% +1.8348% +4.4074%] (p = 0.19 > 0.05)
                        No change in performance detected.

Benchmarking big_merge: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 1104.2s, or reduce sample count to 10.
big_merge               time:   [9.8762 s 10.127 s 10.370 s]                         
                        change: [+6.5407% +10.084% +13.882%] (p = 0.00 < 0.05)
                        Performance has regressed.

```