### PR TITLE
Fix some nightly warnings

### DIFF
--- a/src/hash_table.rs
+++ b/src/hash_table.rs
@@ -16,14 +16,14 @@ struct KeyDataLen {
 #[derive(Clone, Debug)]
 pub(crate) struct HashTable(pub IndexMap<(u64, String), InstrProfRecord>);
 
-fn read_key_data_len(input: &[u8]) -> ParseResult<KeyDataLen> {
+fn read_key_data_len(input: &[u8]) -> ParseResult<'_, KeyDataLen> {
     let (bytes, key_len) = le_u64(input)?;
     let (bytes, data_len) = le_u64(bytes)?;
     let res = KeyDataLen { key_len, data_len };
     Ok((bytes, res))
 }
 
-fn read_key(input: &[u8], key_len: usize) -> ParseResult<Cow<'_, str>> {
+fn read_key(input: &[u8], key_len: usize) -> ParseResult<'_, Cow<'_, str>> {
     if key_len > input.len() {
         Err(nom::Err::Failure(VerboseError::from_error_kind(
             &input[input.len()..],
@@ -39,7 +39,7 @@ fn read_value(
     version: u64,
     mut input: &[u8],
     data_len: usize,
-) -> ParseResult<(u64, InstrProfRecord)> {
+) -> ParseResult<'_, (u64, InstrProfRecord)> {
     if data_len % 8 != 0 {
         // Element is corrupted, it should be aligned
         let errors = vec![(

--- a/src/instrumentation_profile/indexed_profile.rs
+++ b/src/instrumentation_profile/indexed_profile.rs
@@ -164,7 +164,7 @@ fn parse_summary<'a>(
 impl InstrProfReader for IndexedInstrProf {
     type Header = Header;
 
-    fn parse_bytes(mut input: &[u8]) -> ParseResult<InstrumentationProfile> {
+    fn parse_bytes(mut input: &[u8]) -> ParseResult<'_, InstrumentationProfile> {
         let (bytes, header) = Self::parse_header(input)?;
         debug!("Parsed header: {:?}", header);
         let (bytes, summary) = parse_summary(bytes, &header, false)?;
@@ -210,7 +210,7 @@ impl InstrProfReader for IndexedInstrProf {
         Ok((input, profile))
     }
 
-    fn parse_header(input: &[u8]) -> ParseResult<Self::Header> {
+    fn parse_header(input: &[u8]) -> ParseResult<'_, Self::Header> {
         if Self::has_format(input) {
             let (bytes, version) = le_u64(&input[8..])?;
             let (bytes, _) = le_u64(bytes)?;

--- a/src/instrumentation_profile/mod.rs
+++ b/src/instrumentation_profile/mod.rs
@@ -52,9 +52,9 @@ pub fn parse_bytes(data: &[u8]) -> io::Result<InstrumentationProfile> {
 pub trait InstrProfReader {
     type Header;
     /// Parse the profile no lazy parsing here!
-    fn parse_bytes(input: &[u8]) -> ParseResult<InstrumentationProfile>;
+    fn parse_bytes(input: &[u8]) -> ParseResult<'_, InstrumentationProfile>;
     /// Parses a header
-    fn parse_header(input: &[u8]) -> ParseResult<Self::Header>;
+    fn parse_header(input: &[u8]) -> ParseResult<'_, Self::Header>;
     /// Detects that the bytes match the current reader format if it can't read the format it will
     /// return false
     fn has_format(input: impl Read) -> bool;

--- a/src/instrumentation_profile/raw_profile.rs
+++ b/src/instrumentation_profile/raw_profile.rs
@@ -292,7 +292,7 @@ where
 {
     type Header = Header;
 
-    fn parse_bytes(mut input: &[u8]) -> ParseResult<InstrumentationProfile> {
+    fn parse_bytes(mut input: &[u8]) -> ParseResult<'_, InstrumentationProfile> {
         if !input.is_empty() {
             let mut result = InstrumentationProfile::default();
             let (bytes, header) = Self::parse_header(input)?;
@@ -417,7 +417,7 @@ where
         }
     }
 
-    fn parse_header(input: &[u8]) -> ParseResult<Self::Header> {
+    fn parse_header(input: &[u8]) -> ParseResult<'_, Self::Header> {
         if Self::has_format(input) {
             let endianness = file_endianness::<T>(&input[..8].try_into().unwrap());
             let (bytes, version) = nom_u64(endianness)(&input[8..])?;


### PR DESCRIPTION
This commit can be replicated by running `cargo fix` with rustc +nightly-2025-09-07.

An example warning that this fixes:
```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/instrumentation_profile/text_profile.rs:120:39
    |
120 | fn read_value_profile_data(mut input: &[u8]) -> ParseResult<Option<Box<ValueProfDataRecord>>> {
    |                                       ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the same lifetime is hidden here
    |                                       |
    |                                       the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
120 | fn read_value_profile_data(mut input: &[u8]) -> ParseResult<'_, Option<Box<ValueProfDataRecord>>> {
    |                                                             +++
```