### PR TITLE
Try to get tests passing again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           components: llvm-tools-preview
       - name: test
         run: |
-          cargo install cargo-binutils
+          cargo install cargo-binutils@0.3.6
           cargo test
   mac:
     runs-on: macos-latest
@@ -77,5 +77,5 @@ jobs:
           components: llvm-tools-preview
       - name: test
         run: |
-          cargo install cargo-binutils
+          cargo install cargo-binutils@0.3.6
           cargo test


### PR DESCRIPTION
Seems cargo-binutils had a breaking change to CLI stuff and I'm just gonna rollback it's version for now