### PR TITLE
Increase count of all regions assigned to an expression

### DIFF
--- a/src/coverage/coverage_mapping.rs
+++ b/src/coverage/coverage_mapping.rs
@@ -200,7 +200,7 @@ impl<'a> CoverageMapping<'a> {
                             };
 
                             region_ids.insert(counter, count);
-                            if let Some(expr_region) = func.regions.iter().find(|x| {
+                            for expr_region in func.regions.iter().filter(|x| {
                                 x.count.is_expression() && x.count.id == expr_index as u64
                             }) {
                                 let result = report
@@ -256,7 +256,7 @@ impl<'a> CoverageMapping<'a> {
                             };
 
                             region_ids.insert(counter, count);
-                            if let Some(expr_region) = func.regions.iter().find(|x| {
+                            for expr_region in func.regions.iter().filter(|x| {
                                 x.count.is_expression() && x.count.id == *expr_index as u64
                             }) {
                                 let result = report


### PR DESCRIPTION
Fixes #63

I've tested this patch with two different functions. In both cases, there are regions of code that were executed but show with a count of zero:
```rust
pub const fn from_days(days: u64) -> duration {
    if days > u64::max / (60 * 60 * 24) {
         panic!("overflow in duration::from_days");
     }

    duration::from_secs(days * 60 * 60 * 24) // zero count
} // zero count

pub fn filter<T, P>(opt: Option<T>, predicate: P) -> Option<T>
where
    P: FnOnce(&T) -> bool,
    
{
    if let Some(x) = opt {
        if predicate(&x) { // zero count
            return Some(x);
        }
    }
    None
}
```

This patch fixes this issue by assigning the result of a count expression to every region that has the expression ID assigned to it instead of doing it with one region.
