### PR TITLE
Load mapping info lazily

### DIFF
--- a/src/bin/cov.rs
+++ b/src/bin/cov.rs
@@ -52,7 +52,7 @@ impl ShowCommand {
             panic!("Must provide an instrumentation profile");
         };
         let mapping = CoverageMapping::new(&self.objects, &instr_prof, false)?;
-        let mut report = mapping.generate_report();
+        let mut report = mapping.generate_report()?;
         if let Some(remapping) = self.path_remapping.as_ref() {
             report.apply_remapping(remapping);
         }

--- a/tests/cov.rs
+++ b/tests/cov.rs
@@ -232,8 +232,9 @@ fn check_mapping_consistency() {
 
     let instr = parse(prof).unwrap();
 
-    let mapping = CoverageMapping::new(&[obj], &instr, false).unwrap();
-    let info = &mapping.mapping_info[0];
+    let object_files = &[obj];
+    let mapping = CoverageMapping::new(object_files, &instr, false).unwrap();
+    let info = &mapping.mapping_info_iter().next().unwrap().unwrap();
     for record in instr.records() {
         let fun = info
             .cov_fun


### PR DESCRIPTION
This PR does slight changes to the `CoverageMapping` method so it loads the mapping info for each object file lazily.

The main motivation behind this change is that loading the mapping info for a coverage report with many object files can cause memory issues easily. I encountered this issue when trying to load the coverage information resulting from running doctests, where there is one binary for each doctest that's being run.

